### PR TITLE
i18n(es): fill missing key and improve Spanish translation

### DIFF
--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -122,5 +122,6 @@
   "registrationSuccess": "¡Registro exitoso! ✅",
   "copyMnemonic": "Respaldar cuenta",
   "mnemonicCopied": "Mnemotécnica copiada ✅",
-  "noFunds": "Fondos insuficientes"
+  "noFunds": "Fondos insuficientes",
+  "buyXKR": "Comprar/Vender XKR"
 }


### PR DESCRIPTION
Updates Spanish translation by adding missing key(s) to maintain parity with en.json.\n\nCloses kryptokrona/hugin-native#13 (translation update).\n\nXKR payout address:\nSEKReWC16F2butAZaKoAB3QK2Efe85XswB7Jt5Crrp2HjJWbhY8FwR9EJBR9pW8vDtgVTc8zkVV3eeYbkpLqyCHdbhVVKbq2rVJ